### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except:[:index, :show]  
   before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :agreement_userid_editor, only: [:edit, :destroy]
   
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -23,10 +24,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    if @item.user_id == current_user.id
-    else
-      redirect_to root_path
-    end
   end
 
   def update
@@ -39,14 +36,9 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.user_id == current_user.id
-      @item.destroy
-      redirect_to root_path
-    else
-      redirect_to root_path
-    end
+    @item.destroy
+    redirect_to root_path
   end
-
 
   private
 
@@ -56,6 +48,12 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def agreement_userid_editor
+    unless  @item.user.id == current_user.id
+      redirect_to root_path
+    end
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except:[:index, :show]  
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -37,6 +37,16 @@ class ItemsController < ApplicationController
       render 'edit'
     end
   end
+
+  def destroy
+    if @item.user_id == current_user.id
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
+  end
+
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
     <% else %>
       <% if user_signed_in? %>
         <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
  root to: 'items#index'
- resources :items, only: [:index, :new, :create, :show, :edit, :update]
+ resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 
 end


### PR DESCRIPTION
# What
商品削除機能の記述
ルーティング、コントローラーに削除機能の記述を追加
商品詳細ページの”削除ボタン”を押せばアイテムが削除される

# Why
出品を削除することができるため
出品したユーザー以外に削除できない様にするため

# gyazo
・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/fe3ba900f38795bff05715ea04ff134c